### PR TITLE
support of psutils 1.2.1

### DIFF
--- a/core/kdeapp.py
+++ b/core/kdeapp.py
@@ -16,7 +16,11 @@ def running(bus_name, binary):
 def running_binary(binary):
     """Check if the named binary is running."""
     for p in psutil.process_iter():
-        if p.name() == binary:
+        if isinstance(p.name, str):
+            name = p.name
+        else:
+            name = p.name()
+        if name == binary:
             return p
     return False
 


### PR DESCRIPTION
With psutils 1.2.1, Process.name is a str(), not a function.
I use python3-psutil-1.2.1-5.fc21.x86_64 from Fedora.
